### PR TITLE
fix: In Rails 6.1, `errors` is an array of Error

### DIFF
--- a/lib/domain/common/errors.rb
+++ b/lib/domain/common/errors.rb
@@ -2,8 +2,8 @@ module Domain
   module Common
     class Errors < ActiveModel::Errors
       def add_model_error(model, error_prefix = nil)
-        model.errors.each do |key, val|
-          add("#{error_prefix}#{key}", val)
+        model.errors.each do |error|
+          add("#{error_prefix}#{error.attribute}", error.message)
         end
       end
     end


### PR DESCRIPTION
この警告に対応
```
DEPRECATION WARNING: Enumerating ActiveModel::Errors as a hash has been deprecated.
In Rails 6.1, `errors` is an array of Error objects,
therefore it should be accessed by a block with a single block
parameter like this:

person.errors.each do |error|
  attribute = error.attribute
  message = error.message
end

You are passing a block expecting two parameters,
so the old hash behavior is simulated. As this is deprecated,
this will result in an ArgumentError in Rails 6.2.
 (called from add_model_error at /Users/sasaki/work/your-connect/your-connect-rails/vendor/bundle/ruby/2.6.0/bundler/gems/api_modules-ea9f4b68c0b0/lib/domain/common/errors.rb:5)
```