### PR TITLE
internal_server_errorからparamsを削除

### DIFF
--- a/lib/api_modules/controller/error_renderer.rb
+++ b/lib/api_modules/controller/error_renderer.rb
@@ -36,8 +36,8 @@ module ApiModules
         render_error(status: :unauthorized, type: 'authentication-error', code: code, params: params)
       end
 
-      def internal_server_error(code: nil, params: nil)
-        render_error(status: :internal_server_error, type: 'unexpected-error', code: code, params: params)
+      def internal_server_error(code: nil)
+        render_error(status: :internal_server_error, type: 'unexpected-error', code: code)
       end
     end
   end

--- a/lib/domain/base.rb
+++ b/lib/domain/base.rb
@@ -106,12 +106,11 @@ module Domain
       )
     end
 
-    def internal_server_error(code: nil, params: nil)
+    def internal_server_error(code: nil)
       set_errors(
         status: :internal_server_error,
         type: 'unexpected-error',
-        code: code,
-        params: params
+        code: code
       )
     end
 


### PR DESCRIPTION
paramsはクライアントに送信不要なため削除